### PR TITLE
Feature/separate validation properties

### DIFF
--- a/src/main/java/org/ldbcouncil/snb/driver/Client.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Client.java
@@ -1,4 +1,17 @@
 package org.ldbcouncil.snb.driver;
+/**
+ * Client.java
+ * 
+ * Entrypoint for the SNB Driver. This class creates default control classes,
+ * checks which driver mode is specified and starts the application.
+ * There are 4 supported modes (in order of priority):
+ * 1. Create validation parameters
+ * 2. Validate database
+ * 3. Create workload statistics
+ * 4. Execute Benchmark
+ * 
+ * To print the usage help for the driver, use help = true in properties file.
+ */
 
 import org.ldbcouncil.snb.driver.client.CalculateWorkloadStatisticsMode;
 import org.ldbcouncil.snb.driver.client.ClientMode;
@@ -81,11 +94,12 @@ public class Client
             // Print Help
             return new PrintHelpMode( controlService );
         }
-        else if ( null != controlService.configuration().validationParamsCreationOptions() )
+        else if (controlService.configuration().validationCreationParams() )
         {
             // Create Validation Parameters
             DriverConfiguration configuration = controlService.configuration();
             List<String> missingParams = new ArrayList<>();
+
             if ( null == configuration.dbClassName() )
             {
                 missingParams.add( ConsoleAndFileDriverConfiguration.DB_ARG );

--- a/src/main/java/org/ldbcouncil/snb/driver/Client.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Client.java
@@ -21,17 +21,16 @@ import org.ldbcouncil.snb.driver.client.PrintHelpMode;
 import org.ldbcouncil.snb.driver.client.ValidateDatabaseMode;
 import org.ldbcouncil.snb.driver.control.ConsoleAndFileDriverConfiguration;
 import org.ldbcouncil.snb.driver.control.ControlService;
-import org.ldbcouncil.snb.driver.control.DriverConfiguration;
 import org.ldbcouncil.snb.driver.control.DriverConfigurationException;
 import org.ldbcouncil.snb.driver.control.LocalControlService;
 import org.ldbcouncil.snb.driver.control.Log4jLoggingServiceFactory;
 import org.ldbcouncil.snb.driver.control.LoggingService;
 import org.ldbcouncil.snb.driver.control.LoggingServiceFactory;
+import org.ldbcouncil.snb.driver.control.OperationMode;
 import org.ldbcouncil.snb.driver.runtime.ConcurrentErrorReporter;
 import org.ldbcouncil.snb.driver.temporal.SystemTimeSource;
 import org.ldbcouncil.snb.driver.temporal.TimeSource;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -85,99 +84,38 @@ public class Client
         }
     }
 
-    // TODO should not be doing things like ConsoleAndFileDriverConfiguration.DB_ARG
-    // TODO ConsoleAndFileDriverConfiguration could maybe have a DriverParam(enum)-to-String(arg) method?
+    /**
+     * Create instance of operation mode. 
+     * @param controlService ControlService with loaded DriverConfiguration
+     * @return ClientMode object with specified operation mode
+     * @throws ClientException When one or more required parameters are missing
+     */
     public ClientMode getClientModeFor( ControlService controlService ) throws ClientException
     {
         if ( controlService.configuration().shouldPrintHelpString() )
         {
-            // Print Help
             return new PrintHelpMode( controlService );
         }
-        else if (controlService.configuration().validationCreationParams() )
-        {
-            // Create Validation Parameters
-            DriverConfiguration configuration = controlService.configuration();
-            List<String> missingParams = new ArrayList<>();
 
-            if ( null == configuration.dbClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.DB_ARG );
-            }
-            if ( null == configuration.workloadClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.WORKLOAD_ARG );
-            }
-            if ( 0 == configuration.operationCount() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.OPERATION_COUNT_ARG );
-            }
-            if ( false == missingParams.isEmpty() )
-            {
-                throw new ClientException( format( "Missing required parameters: %s", missingParams.toString() ) );
-            }
-            return new CreateValidationParamsMode( controlService, RANDOM_SEED );
-        }
-        else if ( null != controlService.configuration().databaseValidationFilePath() )
+        List<String> missingParams = 
+            ConsoleAndFileDriverConfiguration.checkMissingParams(controlService.configuration());
+        if ( !missingParams.isEmpty() )
         {
-            // Validate Database
-            DriverConfiguration configuration = controlService.configuration();
-            List<String> missingParams = new ArrayList<>();
-            if ( null == configuration.dbClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.DB_ARG );
-            }
-            if ( null == configuration.workloadClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.WORKLOAD_ARG );
-            }
-            if ( false == missingParams.isEmpty() )
-            {
-                throw new ClientException( format( "Missing required parameters: %s", missingParams.toString() ) );
-            }
-            return new ValidateDatabaseMode( controlService );
+            throw new ClientException( format( "Missing required parameters: %s", missingParams.toString() ) );
         }
-        else if ( controlService.configuration().calculateWorkloadStatistics() )
-        {
-            // Calculate Statistics
-            DriverConfiguration configuration = controlService.configuration();
-            List<String> missingParams = new ArrayList<>();
-            if ( null == configuration.workloadClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.WORKLOAD_ARG );
-            }
-            if ( 0 == configuration.operationCount() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.OPERATION_COUNT_ARG );
-            }
-            if ( false == missingParams.isEmpty() )
-            {
-                throw new ClientException( format( "Missing required parameters: %s", missingParams.toString() ) );
-            }
-            return new CalculateWorkloadStatisticsMode( controlService, RANDOM_SEED );
-        }
-        else
-        {
-            // Execute Workload
-            DriverConfiguration configuration = controlService.configuration();
-            List<String> missingParams = new ArrayList<>();
-            if ( null == configuration.dbClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.DB_ARG );
-            }
-            if ( null == configuration.workloadClassName() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.WORKLOAD_ARG );
-            }
-            if ( 0 == configuration.operationCount() )
-            {
-                missingParams.add( ConsoleAndFileDriverConfiguration.OPERATION_COUNT_ARG );
-            }
-            if ( false == missingParams.isEmpty() )
-            {
-                throw new ClientException( format( "Missing required parameters: %s", missingParams.toString() ) );
-            }
-            return new ExecuteWorkloadMode( controlService, new SystemTimeSource(), RANDOM_SEED );
+
+        OperationMode mode = OperationMode.valueOf(controlService.configuration().mode());
+
+        switch (mode) {
+            case create_validation:
+                return new CreateValidationParamsMode( controlService, RANDOM_SEED );
+            case create_statistics:
+                return new CalculateWorkloadStatisticsMode( controlService, RANDOM_SEED );
+            case validate_database:
+                return new ValidateDatabaseMode( controlService );
+            case execute_benchmark:
+            default: // Execute benchmark is default behaviour
+                return new ExecuteWorkloadMode( controlService, new SystemTimeSource(), RANDOM_SEED );
         }
     }
 }

--- a/src/main/java/org/ldbcouncil/snb/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Workload.java
@@ -122,6 +122,8 @@ public abstract class Workload implements Closeable
         return DEFAULT_MAXIMUM_EXPECTED_INTERLEAVE_AS_MILLI;
     }
 
+    public abstract int enabledValidationOperations();
+
     public abstract String serializeOperation( Operation operation ) throws SerializingMarshallingException;
 
     public abstract Operation marshalOperation( String serializedOperation ) throws SerializingMarshallingException;

--- a/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
@@ -92,6 +92,16 @@ public class CreateValidationParamsMode implements ClientMode<Object>
                 format( "Retrieving operation stream for workload: %s", workload.getClass().getSimpleName() ) );
         try
         {
+            int validationSetSize = controlService
+                    .configuration()
+                    .validationParametersSize();
+            int operationCount = validationSetSize * workload.enabledValidationOperations();
+                    
+            /**
+             * Create the workloadstreams which are used to create the validation parameters.
+             * The operation count used here is to ensure enough operations are created to
+             * create the validation parameters.
+             */
             boolean returnStreamsWithDbConnector = false;
             Tuple3<WorkloadStreams,Workload,Long> streamsAndWorkload =
                     WorkloadStreams.createNewWorkloadWithOffsetAndLimitedWorkloadStreams(
@@ -99,7 +109,7 @@ public class CreateValidationParamsMode implements ClientMode<Object>
                             gf,
                             returnStreamsWithDbConnector,
                             0,
-                            controlService.configuration().operationCount(),
+                            operationCount,
                             controlService.loggingServiceFactory()
                     );
             workload = streamsAndWorkload._2();
@@ -140,7 +150,8 @@ public class CreateValidationParamsMode implements ClientMode<Object>
             Iterator<ValidationParam> validationParamsGenerator = new ValidationParamsGenerator(
                     db,
                     w.dbValidationParametersFilter( validationSetSize ),
-                    timeMappedOperations );
+                    timeMappedOperations,
+                    controlService.configuration().validationParametersSize() );
 
             Iterator<String[]> csvRows = new ValidationParamsToCsvRows(
                     validationParamsGenerator,

--- a/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
@@ -1,11 +1,15 @@
 package org.ldbcouncil.snb.driver.client;
+/**
+ * CreateValidationParamsMode.java
+ * 
+ * Create class to generate validation queries with their results and write them to disk.
+ * 
+ */
 
 import org.ldbcouncil.snb.driver.ClientException;
 import org.ldbcouncil.snb.driver.Db;
-import org.ldbcouncil.snb.driver.DbException;
 import org.ldbcouncil.snb.driver.Operation;
 import org.ldbcouncil.snb.driver.Workload;
-import org.ldbcouncil.snb.driver.WorkloadException;
 import org.ldbcouncil.snb.driver.WorkloadStreams;
 import org.ldbcouncil.snb.driver.control.ControlService;
 import org.ldbcouncil.snb.driver.control.LoggingService;
@@ -19,7 +23,6 @@ import org.ldbcouncil.snb.driver.validation.ValidationParamsGenerator;
 import org.ldbcouncil.snb.driver.validation.ValidationParamsToCsvRows;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.Iterator;
 
@@ -35,6 +38,12 @@ public class CreateValidationParamsMode implements ClientMode<Object>
     private Db database = null;
     private Iterator<Operation> timeMappedOperations = null;
 
+    /**
+     * Create class to generate validation queries.
+     * @param controlService Object with functions to time, log and stored init configuration
+     * @param randomSeed The random seed used for the data generator
+     * @throws ClientException
+     */
     public CreateValidationParamsMode( ControlService controlService, long randomSeed ) throws ClientException
     {
         this.controlService = controlService;
@@ -42,6 +51,10 @@ public class CreateValidationParamsMode implements ClientMode<Object>
         this.randomSeed = randomSeed;
     }
 
+    /**
+     * Initializes the validation parameter class. This loads the configuration given through
+     * validation.properties and the database to use to generate the validation parameters.
+     */
     @Override
     public void init() throws ClientException
     {
@@ -103,19 +116,23 @@ public class CreateValidationParamsMode implements ClientMode<Object>
         loggingService.info( controlService.toString() );
     }
 
+    /**
+     * Create validation parameters. 
+     */
     @Override
     public Object startExecutionAndAwaitCompletion() throws ClientException
     {
         try ( Workload w = workload; Db db = database )
         {
             File validationFileToGenerate =
-                    new File( controlService.configuration().validationParamsCreationOptions().filePath() );
+                    new File( controlService.configuration().databaseValidationFilePath() );
+                
             int validationSetSize = controlService
                     .configuration()
-                    .validationParamsCreationOptions()
-                    .validationSetSize();
-            // TODO get from config parameter
-            boolean performSerializationMarshallingChecks = true;
+                    .validationParametersSize();
+
+            boolean performSerializationMarshallingChecks =
+                controlService.configuration().validationSerializationCheck();
 
             loggingService.info(
                     format( "Generating database validation file: %s", validationFileToGenerate.getAbsolutePath() ) );

--- a/src/main/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfiguration.java
@@ -563,7 +563,7 @@ public class ConsoleAndFileDriverConfiguration implements DriverConfiguration
          * Required
          */
         Option modeOption =
-            OptionBuilder.hasArgs( 1 ).withArgName( "name" ).withDescription( MODE_DESCRIPTION )
+            OptionBuilder.hasArgs( 1 ).withArgName( "mode" ).withDescription( MODE_DESCRIPTION )
                 .withLongOpt(MODE_ARG_LONG).create( MODE_ARG );
         options.addOption( modeOption );
 

--- a/src/main/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfiguration.java
@@ -522,7 +522,7 @@ public class ConsoleAndFileDriverConfiguration implements DriverConfiguration
 
     public static Map<String,String> convertLongKeysToShortKeys( Map<String,String> paramsMap )
     {
-        paramsMap = replaceKey( paramsMap, MODE_ARG, MODE_ARG_LONG );
+        paramsMap = replaceKey( paramsMap, MODE_ARG_LONG,  MODE_ARG);
         paramsMap = replaceKey( paramsMap, OPERATION_COUNT_ARG_LONG, OPERATION_COUNT_ARG );
         paramsMap = replaceKey( paramsMap, NAME_ARG_LONG, NAME_ARG );
         paramsMap = replaceKey( paramsMap, WORKLOAD_ARG_LONG, WORKLOAD_ARG );

--- a/src/main/java/org/ldbcouncil/snb/driver/control/DriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/control/DriverConfiguration.java
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeUnit;
 public interface DriverConfiguration
 {
     // General
+    String mode();
+
     String name();
 
     String dbClassName();
@@ -27,15 +29,11 @@ public interface DriverConfiguration
 
     double timeCompressionRatio();
 
-    boolean validationCreationParams();
-
     int validationParametersSize();
 
     boolean validationSerializationCheck();
 
     String databaseValidationFilePath();
-
-    boolean calculateWorkloadStatistics();
 
     long spinnerSleepDurationAsMilli();
 
@@ -60,4 +58,5 @@ public interface DriverConfiguration
     DriverConfiguration applyArg( String argument, String newValue ) throws DriverConfigurationException;
 
     DriverConfiguration applyArgs( Map<String,String> newMap ) throws DriverConfigurationException;
+
 }

--- a/src/main/java/org/ldbcouncil/snb/driver/control/DriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/control/DriverConfiguration.java
@@ -1,10 +1,14 @@
 package org.ldbcouncil.snb.driver.control;
+/**
+ * Interface defining parameters required to run the driver
+ */
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public interface DriverConfiguration
 {
+    // General
     String name();
 
     String dbClassName();
@@ -23,7 +27,11 @@ public interface DriverConfiguration
 
     double timeCompressionRatio();
 
-    ValidationParamOptions validationParamsCreationOptions();
+    boolean validationCreationParams();
+
+    int validationParametersSize();
+
+    boolean validationSerializationCheck();
 
     String databaseValidationFilePath();
 
@@ -52,11 +60,4 @@ public interface DriverConfiguration
     DriverConfiguration applyArg( String argument, String newValue ) throws DriverConfigurationException;
 
     DriverConfiguration applyArgs( Map<String,String> newMap ) throws DriverConfigurationException;
-
-    interface ValidationParamOptions
-    {
-        String filePath();
-
-        int validationSetSize();
-    }
 }

--- a/src/main/java/org/ldbcouncil/snb/driver/control/OperationMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/control/OperationMode.java
@@ -1,0 +1,8 @@
+package org.ldbcouncil.snb.driver.control;
+
+public enum OperationMode {
+    create_validation,
+    validate_database,
+    create_statistics,
+    execute_benchmark;
+}

--- a/src/main/java/org/ldbcouncil/snb/driver/validation/DbValidator.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/validation/DbValidator.java
@@ -18,6 +18,15 @@ import static java.lang.String.format;
 
 public class DbValidator
 {
+    /**
+     * Validate the database using generated validation parameters.
+     * @param validationParameters Iterator of validation parameters created using 'create_validation' mode
+     * @param db The database connector 
+     * @param validationParamsCount Total validation parameters
+     * @param workload The workload to use, e.g. @see org.ldbcouncil.snb.driver.workloads.interactive.LdbcSnbInteractiveWorkload
+     * @return
+     * @throws WorkloadException
+     */
     public DbValidationResult validate( Iterator<ValidationParam> validationParameters,
             Db db,
             int validationParamsCount,

--- a/src/main/java/org/ldbcouncil/snb/driver/validation/ValidationParamsGenerator.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/validation/ValidationParamsGenerator.java
@@ -1,4 +1,12 @@
 package org.ldbcouncil.snb.driver.validation;
+/**
+ * Class generating validation parameters for specified workload.
+ * To generate the validation parameters, the following is required:
+ * - A database where the data is already loaded
+ * - A validation parameters filter to determine which queries needs to be part of the validation parameters
+ * - An iterator with time mapped operations
+ */
+
 
 import org.ldbcouncil.snb.driver.Db;
 import org.ldbcouncil.snb.driver.DbConnectionState;
@@ -29,10 +37,12 @@ public class ValidationParamsGenerator extends Generator<ValidationParam>
     private int entriesWrittenSoFar;
     private boolean needMoreValidationParameters;
     private final List<Operation> injectedOperations;
+    private int requiredValidationParameterSize;
 
     public ValidationParamsGenerator( Db db,
             DbValidationParametersFilter dbValidationParametersFilter,
-            Iterator<Operation> operations )
+            Iterator<Operation> operations,
+            int requiredValidationParameterSize )
     {
         this.db = db;
         this.dbValidationParametersFilter = dbValidationParametersFilter;
@@ -41,6 +51,7 @@ public class ValidationParamsGenerator extends Generator<ValidationParam>
         this.entriesWrittenSoFar = 0;
         this.needMoreValidationParameters = true;
         this.injectedOperations = new ArrayList<>();
+        this.requiredValidationParameterSize = requiredValidationParameterSize;
     }
 
     public int entriesWrittenSoFar()
@@ -51,7 +62,7 @@ public class ValidationParamsGenerator extends Generator<ValidationParam>
     @Override
     protected ValidationParam doNext() throws GeneratorException
     {
-        while ( (injectedOperations.size() > 0 || operations.hasNext()) && needMoreValidationParameters )
+        while ( (injectedOperations.size() > 0 || operations.hasNext()) && needMoreValidationParameters && (requiredValidationParameterSize > entriesWrittenSoFar) )
         {
             Operation operation;
             if ( injectedOperations.isEmpty() )
@@ -64,7 +75,9 @@ public class ValidationParamsGenerator extends Generator<ValidationParam>
             }
 
             if ( false == dbValidationParametersFilter.useOperation( operation ) )
-            { continue; }
+            { 
+                continue; 
+            }
 
             OperationHandlerRunnableContext operationHandlerRunner;
             try

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -114,9 +114,10 @@ public class LdbcSnbInteractiveWorkload extends Workload
     @Override
     public void onInit( Map<String,String> params ) throws WorkloadException
     {
-        List<String> compulsoryKeys = Lists.newArrayList(
-                LdbcSnbInteractiveWorkloadConfiguration.PARAMETERS_DIRECTORY );
-
+        List<String> compulsoryKeys = Lists.newArrayList();
+        // if (!Boolean.parseBoolean(params.get( ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG ))){
+            compulsoryKeys.add( LdbcSnbInteractiveWorkloadConfiguration.PARAMETERS_DIRECTORY );
+        // }
         compulsoryKeys.addAll( LdbcSnbInteractiveWorkloadConfiguration.LONG_READ_OPERATION_ENABLE_KEYS );
         compulsoryKeys.addAll( LdbcSnbInteractiveWorkloadConfiguration.WRITE_OPERATION_ENABLE_KEYS );
         compulsoryKeys.addAll( LdbcSnbInteractiveWorkloadConfiguration.SHORT_READ_OPERATION_ENABLE_KEYS );

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
@@ -63,6 +63,11 @@ public class SimpleWorkload extends Workload
     }
 
     @Override
+    public int enabledValidationOperations(){
+        return 0;
+    }
+
+    @Override
     public WorkloadStreams getStreams( GeneratorFactory gf, boolean hasDbConnected ) throws WorkloadException
     {
         long workloadStartTimeAsMilli = 0;

--- a/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
@@ -901,6 +901,12 @@ public class WorkloadStreamsTest
         }
 
         @Override
+        public int enabledValidationOperations()
+        {
+            return 0;
+        }
+
+        @Override
         protected void onClose() throws IOException
         {
         }

--- a/src/test/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfigurationTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfigurationTest.java
@@ -97,7 +97,9 @@ public class ConsoleAndFileDriverConfigurationTest
         TimeUnit timeUnit = TimeUnit.MILLISECONDS;
         String resultDirPath = "results dir";
         Double timeCompressionRatio = 1.0;
-        ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationCreationParams = null;
+        boolean validationCreationParams = false;
+        int validationParamsSize = 0;
+        boolean validationSerializationCheck = false;
         String databaseValidationFilePath = null;
         boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
@@ -121,6 +123,8 @@ public class ConsoleAndFileDriverConfigurationTest
                 resultDirPath,
                 timeCompressionRatio,
                 validationCreationParams,
+                validationParamsSize,
+                validationSerializationCheck,
                 databaseValidationFilePath,
                 calculateWorkloadStatistics,
                 spinnerSleepDuration,
@@ -186,9 +190,6 @@ public class ConsoleAndFileDriverConfigurationTest
         String workloadClassName = "workload";
         long operationCount = 2;
 
-        ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParamOptions =
-                new ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions( "file", 2 );
-
         Map<String,String> paramsFromPublicStaticDefaultValuesAsMap = new HashMap<>();
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.THREADS_ARG,
@@ -208,8 +209,14 @@ public class ConsoleAndFileDriverConfigurationTest
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
-                ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                validationParamOptions.toCommandlineString() );
+            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
+            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING );
+        paramsFromPublicStaticDefaultValuesAsMap.put(
+            ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING );
+        paramsFromPublicStaticDefaultValuesAsMap.put(
+            ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING );
@@ -326,12 +333,15 @@ public class ConsoleAndFileDriverConfigurationTest
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
-        if ( null != ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT )
-        {
-            paramsFromPublicStaticDefaultValuesAsMap.put(
-                    ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                    ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT.toCommandlineString() );
-        }
+        paramsFromPublicStaticDefaultValuesAsMap.put(
+            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
+            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING );
+        paramsFromPublicStaticDefaultValuesAsMap.put(
+            ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING );
+        paramsFromPublicStaticDefaultValuesAsMap.put(
+            ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING );
@@ -399,11 +409,15 @@ public class ConsoleAndFileDriverConfigurationTest
                 ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT_STRING );
         optionalParamsMap.put( ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
-        if ( null != ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT )
-        {
-            optionalParamsMap.put( ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                    ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT.toCommandlineString() );
-        }
+
+        optionalParamsMap.put( ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
+            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING);
+        optionalParamsMap.put( ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING);
+        
+        optionalParamsMap.put( ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_ARG,
+            ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT_STRING);
+
         if ( null != ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING )
         {
             optionalParamsMap.put( ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
@@ -446,19 +460,26 @@ public class ConsoleAndFileDriverConfigurationTest
         if ( null != ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT )
         {
             optionalParamsArgsList.addAll(
-                    Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_ARG,
-                            ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT_STRING ) );
+                Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_ARG,
+                    ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT_STRING ) );
         }
         optionalParamsArgsList.addAll(
-                Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
-                        ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING ) );
-        if ( null != ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT )
-        {
+            Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
+                ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING ) );
+        
+        optionalParamsArgsList.addAll(
+            Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
+                ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING ) );
+
+        if (ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT == false){
             optionalParamsArgsList.addAll(
-                    Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT
-                                    .toCommandlineString() ) );
+                Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_ARG,
+                        ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT_STRING ) );
         }
+        optionalParamsArgsList.addAll(
+            Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
+                ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING ) );
+    
         if ( null != ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING )
         {
             optionalParamsArgsList.addAll(
@@ -528,9 +549,12 @@ public class ConsoleAndFileDriverConfigurationTest
                 is( ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT ) );
         assertThat( configurationFromParams.timeCompressionRatio(),
                 is( ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT ) );
-        assertThat( configurationFromParams.validationParamsCreationOptions(),
-                is( (DriverConfiguration.ValidationParamOptions) ConsoleAndFileDriverConfiguration
-                        .CREATE_VALIDATION_PARAMS_DEFAULT ) );
+        assertThat( configurationFromParams.validationCreationParams(), 
+                is( ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT ));
+        assertThat( configurationFromParams.validationParametersSize(),
+                is( ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT));
+        assertThat( configurationFromParams.validationSerializationCheck(),
+                is( ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT));
         assertThat( configurationFromParams.databaseValidationFilePath(),
                 is( ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT ) );
         assertThat( configurationFromParams.calculateWorkloadStatistics(),
@@ -558,9 +582,10 @@ public class ConsoleAndFileDriverConfigurationTest
         TimeUnit timeUnit = TimeUnit.SECONDS;
         String resultDirPath = null;
         Double timeCompressionRatio = 1.0;
-        ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams =
-                new ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions( "file", 1 );
-        String dbValidationFilePath = null;
+        boolean validationCreationParams = true;
+        int validationParamsSize = 1;
+        boolean validationSerializationCheck = true;
+        String dbValidationFilePath = "file";
         boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
         boolean printHelp = false;
@@ -580,7 +605,9 @@ public class ConsoleAndFileDriverConfigurationTest
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationParams,
+                validationCreationParams,
+                validationParamsSize,
+                validationSerializationCheck,
                 dbValidationFilePath,
                 calculateWorkloadStatistics,
                 spinnerSleepDuration,
@@ -601,8 +628,9 @@ public class ConsoleAndFileDriverConfigurationTest
         assertThat( params.timeUnit(), equalTo( timeUnit ) );
         assertThat( params.resultDirPath(), equalTo( resultDirPath ) );
         assertThat( params.timeCompressionRatio(), equalTo( timeCompressionRatio ) );
-        assertThat( params.validationParamsCreationOptions(),
-                equalTo( (DriverConfiguration.ValidationParamOptions) validationParams ) );
+        assertThat( params.validationCreationParams(), equalTo( validationCreationParams ) );
+        assertThat( params.validationSerializationCheck(), equalTo( validationSerializationCheck ) );
+        assertThat( params.validationParametersSize(), equalTo( validationParamsSize ) );
         assertThat( params.databaseValidationFilePath(), equalTo( dbValidationFilePath ) );
         assertThat( params.calculateWorkloadStatistics(), equalTo( calculateWorkloadStatistics ) );
         assertThat( params.shouldPrintHelpString(), equalTo( printHelp ) );

--- a/src/test/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfigurationTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfigurationTest.java
@@ -91,17 +91,16 @@ public class ConsoleAndFileDriverConfigurationTest
     public void toMapThenFromMapShouldReturnSameResultWhenAllParamsAreInitiallySetViaConstructor()
             throws DriverConfigurationException
     {
+        String mode = "execute_benchmark";
         long operationCount = 2;
         int threadCount = 4;
         int statusDisplayInterval = 1000;
         TimeUnit timeUnit = TimeUnit.MILLISECONDS;
         String resultDirPath = "results dir";
         Double timeCompressionRatio = 1.0;
-        boolean validationCreationParams = false;
         int validationParamsSize = 0;
         boolean validationSerializationCheck = false;
         String databaseValidationFilePath = null;
-        boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
         boolean printHelp = false;
         String name = "LDBC-SNB";
@@ -113,6 +112,7 @@ public class ConsoleAndFileDriverConfigurationTest
 
         ConsoleAndFileDriverConfiguration configurationBefore = new ConsoleAndFileDriverConfiguration(
                 paramsMap,
+                mode,
                 name,
                 DummyLdbcSnbInteractiveDb.class.getName(),
                 LdbcSnbInteractiveWorkload.class.getName(),
@@ -122,11 +122,9 @@ public class ConsoleAndFileDriverConfigurationTest
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationCreationParams,
                 validationParamsSize,
                 validationSerializationCheck,
                 databaseValidationFilePath,
-                calculateWorkloadStatistics,
                 spinnerSleepDuration,
                 printHelp,
                 ignoreScheduledStartTimes,
@@ -209,9 +207,6 @@ public class ConsoleAndFileDriverConfigurationTest
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
-            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING );
-        paramsFromPublicStaticDefaultValuesAsMap.put(
             ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
             ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
@@ -220,9 +215,6 @@ public class ConsoleAndFileDriverConfigurationTest
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING );
-        paramsFromPublicStaticDefaultValuesAsMap.put(
-                ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_ARG,
-                ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.HELP_ARG, ConsoleAndFileDriverConfiguration.HELP_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
@@ -334,9 +326,6 @@ public class ConsoleAndFileDriverConfigurationTest
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
-            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING );
-        paramsFromPublicStaticDefaultValuesAsMap.put(
             ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
             ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
@@ -345,9 +334,6 @@ public class ConsoleAndFileDriverConfigurationTest
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                 ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING );
-        paramsFromPublicStaticDefaultValuesAsMap.put(
-                ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_ARG,
-                ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
                 ConsoleAndFileDriverConfiguration.HELP_ARG, ConsoleAndFileDriverConfiguration.HELP_DEFAULT_STRING );
         paramsFromPublicStaticDefaultValuesAsMap.put(
@@ -410,8 +396,6 @@ public class ConsoleAndFileDriverConfigurationTest
         optionalParamsMap.put( ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_ARG,
                 ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT_STRING );
 
-        optionalParamsMap.put( ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-            ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING);
         optionalParamsMap.put( ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG,
             ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT_STRING);
         
@@ -423,8 +407,6 @@ public class ConsoleAndFileDriverConfigurationTest
             optionalParamsMap.put( ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                     ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING );
         }
-        optionalParamsMap.put( ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_ARG,
-                ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT_STRING );
         optionalParamsMap.put( ConsoleAndFileDriverConfiguration.HELP_ARG,
                 ConsoleAndFileDriverConfiguration.HELP_DEFAULT_STRING );
         optionalParamsMap.put( ConsoleAndFileDriverConfiguration.IGNORE_SCHEDULED_START_TIMES_ARG,
@@ -476,21 +458,14 @@ public class ConsoleAndFileDriverConfigurationTest
                 Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_ARG,
                         ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT_STRING ) );
         }
-        optionalParamsArgsList.addAll(
-            Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_DEFAULT_STRING ) );
-    
+
         if ( null != ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING )
         {
             optionalParamsArgsList.addAll(
                     Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                             ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT_STRING ) );
         }
-        if ( ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT )
-        {
-            optionalParamsArgsList.addAll(
-                    Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_ARG ) );
-        }
+
         if ( ConsoleAndFileDriverConfiguration.HELP_DEFAULT )
         { optionalParamsArgsList.addAll( Lists.newArrayList( "-" + ConsoleAndFileDriverConfiguration.HELP_ARG ) ); }
         if ( ConsoleAndFileDriverConfiguration.IGNORE_SCHEDULED_START_TIMES_DEFAULT )
@@ -549,16 +524,12 @@ public class ConsoleAndFileDriverConfigurationTest
                 is( ConsoleAndFileDriverConfiguration.RESULT_DIR_PATH_DEFAULT ) );
         assertThat( configurationFromParams.timeCompressionRatio(),
                 is( ConsoleAndFileDriverConfiguration.TIME_COMPRESSION_RATIO_DEFAULT ) );
-        assertThat( configurationFromParams.validationCreationParams(), 
-                is( ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT ));
         assertThat( configurationFromParams.validationParametersSize(),
                 is( ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_DEFAULT));
         assertThat( configurationFromParams.validationSerializationCheck(),
                 is( ConsoleAndFileDriverConfiguration.VALIDATION_SERIALIZATION_CHECK_DEFAULT));
         assertThat( configurationFromParams.databaseValidationFilePath(),
                 is( ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_DEFAULT ) );
-        assertThat( configurationFromParams.calculateWorkloadStatistics(),
-                is( ConsoleAndFileDriverConfiguration.CALCULATE_WORKLOAD_STATISTICS_DEFAULT ) );
         assertThat( configurationFromParams.shouldPrintHelpString(),
                 is( ConsoleAndFileDriverConfiguration.HELP_DEFAULT ) );
         assertThat( configurationFromParams.ignoreScheduledStartTimes(),
@@ -573,6 +544,7 @@ public class ConsoleAndFileDriverConfigurationTest
     public void shouldReturnSameAsConstructedWith()
     {
         Map<String,String> paramsMap = new HashMap<>();
+        String mode = "execute_benchmark";
         String name = "name";
         String dbClassName = "dbClassName";
         String workloadClassName = "workloadClassName";
@@ -582,11 +554,9 @@ public class ConsoleAndFileDriverConfigurationTest
         TimeUnit timeUnit = TimeUnit.SECONDS;
         String resultDirPath = null;
         Double timeCompressionRatio = 1.0;
-        boolean validationCreationParams = true;
         int validationParamsSize = 1;
         boolean validationSerializationCheck = true;
         String dbValidationFilePath = "file";
-        boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
         boolean printHelp = false;
         boolean ignoreScheduledStartTimes = false;
@@ -596,6 +566,7 @@ public class ConsoleAndFileDriverConfigurationTest
 
         ConsoleAndFileDriverConfiguration params = new ConsoleAndFileDriverConfiguration(
                 paramsMap,
+                mode,
                 name,
                 dbClassName,
                 workloadClassName,
@@ -605,11 +576,9 @@ public class ConsoleAndFileDriverConfigurationTest
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationCreationParams,
                 validationParamsSize,
                 validationSerializationCheck,
                 dbValidationFilePath,
-                calculateWorkloadStatistics,
                 spinnerSleepDuration,
                 printHelp,
                 ignoreScheduledStartTimes,
@@ -619,6 +588,7 @@ public class ConsoleAndFileDriverConfigurationTest
         );
 
         assertThat( params.asMap(), equalTo( paramsMap ) );
+        assertThat( params.mode(), equalTo( mode ) );
         assertThat( params.name(), equalTo( name ) );
         assertThat( params.dbClassName(), equalTo( dbClassName ) );
         assertThat( params.workloadClassName(), equalTo( workloadClassName ) );
@@ -628,11 +598,9 @@ public class ConsoleAndFileDriverConfigurationTest
         assertThat( params.timeUnit(), equalTo( timeUnit ) );
         assertThat( params.resultDirPath(), equalTo( resultDirPath ) );
         assertThat( params.timeCompressionRatio(), equalTo( timeCompressionRatio ) );
-        assertThat( params.validationCreationParams(), equalTo( validationCreationParams ) );
         assertThat( params.validationSerializationCheck(), equalTo( validationSerializationCheck ) );
         assertThat( params.validationParametersSize(), equalTo( validationParamsSize ) );
         assertThat( params.databaseValidationFilePath(), equalTo( dbValidationFilePath ) );
-        assertThat( params.calculateWorkloadStatistics(), equalTo( calculateWorkloadStatistics ) );
         assertThat( params.shouldPrintHelpString(), equalTo( printHelp ) );
         assertThat( params.ignoreScheduledStartTimes(), equalTo( ignoreScheduledStartTimes ) );
         assertThat( params.spinnerSleepDurationAsMilli(), equalTo( spinnerSleepDuration ) );

--- a/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
@@ -345,6 +345,7 @@ public class TimeMappingOperationGeneratorTest
         paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.PARAMETERS_DIRECTORY,
                 TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
         // Driver-specific parameters
+        String mode = "mode";
         String name = "name";
         String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
         String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -355,10 +356,8 @@ public class TimeMappingOperationGeneratorTest
         String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
         double timeCompressionRatio = 1.0;
         String dbValidationFilePath = null;
-        boolean validationCreationParams = false;
         boolean validationSerializationCheck = false;
         int validationParamsSize = 0;
-        boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
         boolean printHelp = false;
         boolean ignoreScheduledStartTimes = false;
@@ -368,6 +367,7 @@ public class TimeMappingOperationGeneratorTest
 
         ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                 paramsMap,
+                mode,
                 name,
                 dbClassName,
                 workloadClassName,
@@ -377,11 +377,9 @@ public class TimeMappingOperationGeneratorTest
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationCreationParams,
                 validationParamsSize,
                 validationSerializationCheck,
                 dbValidationFilePath,
-                calculateWorkloadStatistics,
                 spinnerSleepDuration,
                 printHelp,
                 ignoreScheduledStartTimes,

--- a/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
@@ -354,8 +354,10 @@ public class TimeMappingOperationGeneratorTest
         TimeUnit timeUnit = TimeUnit.MILLISECONDS;
         String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
         double timeCompressionRatio = 1.0;
-        ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
         String dbValidationFilePath = null;
+        boolean validationCreationParams = false;
+        boolean validationSerializationCheck = false;
+        int validationParamsSize = 0;
         boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0L;
         boolean printHelp = false;
@@ -375,7 +377,9 @@ public class TimeMappingOperationGeneratorTest
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationParams,
+                validationCreationParams,
+                validationParamsSize,
+                validationSerializationCheck,
                 dbValidationFilePath,
                 calculateWorkloadStatistics,
                 spinnerSleepDuration,

--- a/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/generator/TimeMappingOperationGeneratorTest.java
@@ -345,7 +345,7 @@ public class TimeMappingOperationGeneratorTest
         paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.PARAMETERS_DIRECTORY,
                 TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
         // Driver-specific parameters
-        String mode = "mode";
+        String mode = "execute_benchmark";
         String name = "name";
         String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
         String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/QueuePerformanceTests.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/QueuePerformanceTests.java
@@ -68,6 +68,7 @@ public class QueuePerformanceTests
                 TestUtils.getResource( "/" ).getAbsolutePath() );
         // LDBC Interactive Workload-specific parameters
         // Driver-specific parameters
+        String mode = null;
         String name = null;
         String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
         String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -78,10 +79,8 @@ public class QueuePerformanceTests
         String resultDirPath = null;
         double timeCompressionRatio = 1.0;
         String dbValidationFilePath = null;
-        boolean validationCreationParams = false;
         boolean validationSerializationCheck = false;
         int validationParamsSize = 0;
-        boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0l;
         boolean printHelp = false;
         boolean ignoreScheduledStartTimes = false;
@@ -91,6 +90,7 @@ public class QueuePerformanceTests
 
         DriverConfiguration config = new ConsoleAndFileDriverConfiguration(
                 paramsMap,
+                mode,
                 name,
                 dbClassName,
                 workloadClassName,
@@ -100,11 +100,9 @@ public class QueuePerformanceTests
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationCreationParams,
                 validationParamsSize,
                 validationSerializationCheck,
                 dbValidationFilePath,
-                calculateWorkloadStatistics,
                 spinnerSleepDuration,
                 printHelp,
                 ignoreScheduledStartTimes,

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/QueuePerformanceTests.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/QueuePerformanceTests.java
@@ -77,8 +77,10 @@ public class QueuePerformanceTests
         TimeUnit timeUnit = TimeUnit.MILLISECONDS;
         String resultDirPath = null;
         double timeCompressionRatio = 1.0;
-        ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
         String dbValidationFilePath = null;
+        boolean validationCreationParams = false;
+        boolean validationSerializationCheck = false;
+        int validationParamsSize = 0;
         boolean calculateWorkloadStatistics = false;
         long spinnerSleepDuration = 0l;
         boolean printHelp = false;
@@ -98,7 +100,9 @@ public class QueuePerformanceTests
                 timeUnit,
                 resultDirPath,
                 timeCompressionRatio,
-                validationParams,
+                validationCreationParams,
+                validationParamsSize,
+                validationSerializationCheck,
                 dbValidationFilePath,
                 calculateWorkloadStatistics,
                 spinnerSleepDuration,

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
@@ -99,6 +99,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
+            String mode = null;
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -107,10 +108,8 @@ public class WorkloadRunnerTest
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.0000001;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = false;
@@ -120,6 +119,7 @@ public class WorkloadRunnerTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -129,11 +129,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,
@@ -306,6 +304,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
+            String mode = null;
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -314,10 +313,8 @@ public class WorkloadRunnerTest
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.0000001;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = false;
@@ -327,6 +324,7 @@ public class WorkloadRunnerTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -336,11 +334,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,
@@ -531,6 +527,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
+            String mode = null;
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -539,10 +536,8 @@ public class WorkloadRunnerTest
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.000001;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = false;
@@ -552,6 +547,7 @@ public class WorkloadRunnerTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -561,11 +557,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,
@@ -802,6 +796,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
+            String mode = null;
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -810,10 +805,8 @@ public class WorkloadRunnerTest
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 1.0;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = true;
@@ -823,6 +816,7 @@ public class WorkloadRunnerTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -832,11 +826,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
@@ -106,8 +106,10 @@ public class WorkloadRunnerTest
             TimeUnit timeUnit = TimeUnit.NANOSECONDS;
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.0000001;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
@@ -127,7 +129,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,
@@ -309,8 +313,10 @@ public class WorkloadRunnerTest
             TimeUnit timeUnit = TimeUnit.NANOSECONDS;
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.0000001;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
@@ -330,7 +336,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,
@@ -530,8 +538,10 @@ public class WorkloadRunnerTest
             TimeUnit timeUnit = TimeUnit.NANOSECONDS;
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 0.000001;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
@@ -551,7 +561,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,
@@ -797,8 +809,10 @@ public class WorkloadRunnerTest
             TimeUnit timeUnit = TimeUnit.NANOSECONDS;
             String resultDirPath = temporaryFolder.newFolder().getAbsolutePath();
             double timeCompressionRatio = 1.0;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0L;
             boolean printHelp = false;
@@ -818,7 +832,9 @@ public class WorkloadRunnerTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunnerTest.java
@@ -99,7 +99,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
-            String mode = null;
+            String mode = "execute_benchmark";
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
@@ -527,7 +527,7 @@ public class WorkloadRunnerTest
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY,
                     TestUtils.getResource( "/snb/interactive/" ).getAbsolutePath() );
             // Driver-specific parameters
-            String mode = null;
+            String mode = "execute_benchmark";
             String name = null;
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/WorkloadTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/WorkloadTest.java
@@ -483,6 +483,7 @@ public abstract class WorkloadTest
         }
     }
 
+    // TODO: Test should write to memory, not to physical disk. Mock the file
     @Test
     public void shouldCreateValidationParametersThenUseThemToPerformDatabaseValidationThenPass() throws Exception
     {
@@ -494,16 +495,10 @@ public abstract class WorkloadTest
             File validationParamsFile = temporaryFolder.newFile();
             assertThat( validationParamsFile.length(), is( 0l ) );
 
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams =
-                    new ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions(
-                            validationParamsFile.getAbsolutePath(),
-                            500
-                    );
 
-            configuration = configuration.applyArg(
-                    ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG,
-                    validationParams.toCommandlineString()
-            );
+            configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG, Boolean.toString(true));
+            configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG, validationParamsFile.getAbsolutePath());
+            configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG, Integer.toString(500));
 
             ResultsDirectory resultsDirectory = new ResultsDirectory( configuration );
 

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/WorkloadTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/WorkloadTest.java
@@ -109,6 +109,17 @@ public abstract class WorkloadTest
         return configurationsWithSkip;
     }
 
+    private List<DriverConfiguration> withMode( List<DriverConfiguration> configurations, String mode )
+            throws IOException, DriverConfigurationException
+    {
+        List<DriverConfiguration> configurationsWithSkip = new ArrayList<>();
+        for ( DriverConfiguration configuration : configurations )
+        {
+            configuration.applyArg( ConsoleAndFileDriverConfiguration.MODE_ARG, mode );
+        }
+        return configurationsWithSkip;
+    }
+
     @Test
     public void shouldHaveOneToOneMappingBetweenOperationClassesAndOperationTypes() throws Exception
     {
@@ -483,11 +494,11 @@ public abstract class WorkloadTest
         }
     }
 
-    // TODO: Test should write to memory, not to physical disk. Mock the file
+    // TODO: Test should write to memory, not to physical disk. Mock the file and pass it over to the validate_database
     @Test
     public void shouldCreateValidationParametersThenUseThemToPerformDatabaseValidationThenPass() throws Exception
     {
-        for ( DriverConfiguration configuration : withSkip( withWarmup( withTempResultDirs( configurations() ) ) ) )
+        for ( DriverConfiguration configuration : withSkip( withWarmup( withTempResultDirs(withMode( configurations(), "create_validation" )) ) ) )
         {
             // **************************************************
             // where validation parameters should be written (ensure file does not yet exist)
@@ -495,8 +506,6 @@ public abstract class WorkloadTest
             File validationParamsFile = temporaryFolder.newFile();
             assertThat( validationParamsFile.length(), is( 0l ) );
 
-
-            configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG, Boolean.toString(true));
             configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG, validationParamsFile.getAbsolutePath());
             configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.VALIDATION_PARAMS_SIZE_ARG, Integer.toString(500));
 
@@ -530,8 +539,8 @@ public abstract class WorkloadTest
             // **************************************************
             // configuration for using validation parameters file to validate the database
             // **************************************************
+            configuration = configuration.applyArg(ConsoleAndFileDriverConfiguration.MODE_ARG, "validate_database");
             configuration = configuration
-                    .applyArg( ConsoleAndFileDriverConfiguration.CREATE_VALIDATION_PARAMS_ARG, null )
                     .applyArg(
                             ConsoleAndFileDriverConfiguration.DB_VALIDATION_FILE_PATH_ARG,
                             validationParamsFile.getAbsolutePath()

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
@@ -37,6 +37,11 @@ public class DummyWorkload extends Workload
     }
 
     @Override
+    public int enabledValidationOperations(){
+        return 0;
+    }
+
+    @Override
     public Map<Integer,Class<? extends Operation>> operationTypeToClassMapping()
     {
         return OPERATION_TYPE_CLASS_MAPPING;

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/interactive/performance/InteractiveWorkloadPerformanceTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/interactive/performance/InteractiveWorkloadPerformanceTest.java
@@ -113,8 +113,10 @@ public class InteractiveWorkloadPerformanceTest
             TimeUnit timeUnit = TimeUnit.MICROSECONDS;
             String resultDirPath = resultsDir;
             double timeCompressionRatio = 0.0000001;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0;
             boolean printHelp = false;
@@ -134,7 +136,9 @@ public class InteractiveWorkloadPerformanceTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,
@@ -262,8 +266,6 @@ public class InteractiveWorkloadPerformanceTest
         try
         {
             Map<String,String> paramsMap = LdbcSnbInteractiveWorkloadConfiguration.defaultConfigSF1();
-//            Map<String, String> paramsMap = LdbcSnbInteractiveWorkloadConfiguration.defaultWriteOnlyConfig();
-//            Map<String, String> paramsMap = LdbcSnbInteractiveWorkloadConfiguration.defaultReadOnlyConfig();
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.PARAMETERS_DIRECTORY, parametersDir );
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATES_DIRECTORY, updateStreamsDir );
             paramsMap.put( LdbcSnbInteractiveWorkloadConfiguration.UPDATE_STREAM_PARSER,
@@ -278,8 +280,10 @@ public class InteractiveWorkloadPerformanceTest
             TimeUnit timeUnit = TimeUnit.MICROSECONDS;
             String resultDirPath = resultsDir;
             double timeCompressionRatio = 0.0000001;
-            ConsoleAndFileDriverConfiguration.ConsoleAndFileValidationParamOptions validationParams = null;
             String dbValidationFilePath = null;
+            boolean validationCreationParams = false;
+            boolean validationSerializationCheck = false;
+            int validationParamsSize = 0;
             // TODO should be false
             boolean calculateWorkloadStatistics = true;
             long spinnerSleepDuration = 0;
@@ -300,7 +304,9 @@ public class InteractiveWorkloadPerformanceTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationParams,
+                    validationCreationParams,
+                    validationParamsSize,
+                    validationSerializationCheck,
                     dbValidationFilePath,
                     calculateWorkloadStatistics,
                     spinnerSleepDuration,

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/interactive/performance/InteractiveWorkloadPerformanceTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/interactive/performance/InteractiveWorkloadPerformanceTest.java
@@ -107,6 +107,7 @@ public class InteractiveWorkloadPerformanceTest
                     Long.toString( TimeUnit.MICROSECONDS.toNanos( 100 ) ) );
             paramsMap.put( DummyLdbcSnbInteractiveDb.SLEEP_TYPE_ARG, DummyLdbcSnbInteractiveDb.SleepType.SPIN.name() );
             // Driver-specific parameters
+            String mode = "execute_benchmark";
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
             int statusDisplayInterval = 2;
@@ -114,10 +115,8 @@ public class InteractiveWorkloadPerformanceTest
             String resultDirPath = resultsDir;
             double timeCompressionRatio = 0.0000001;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            boolean calculateWorkloadStatistics = false;
             long spinnerSleepDuration = 0;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = true;
@@ -127,6 +126,7 @@ public class InteractiveWorkloadPerformanceTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -136,11 +136,9 @@ public class InteractiveWorkloadPerformanceTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,
@@ -274,6 +272,7 @@ public class InteractiveWorkloadPerformanceTest
                     Long.toString( TimeUnit.MICROSECONDS.toNanos( 0 ) ) );
             paramsMap.put( DummyLdbcSnbInteractiveDb.SLEEP_TYPE_ARG, DummyLdbcSnbInteractiveDb.SleepType.SPIN.name() );
             // Driver-specific parameters
+            String mode = "execute_benchmark";
             String dbClassName = DummyLdbcSnbInteractiveDb.class.getName();
             String workloadClassName = LdbcSnbInteractiveWorkload.class.getName();
             int statusDisplayInterval = 2;
@@ -281,11 +280,8 @@ public class InteractiveWorkloadPerformanceTest
             String resultDirPath = resultsDir;
             double timeCompressionRatio = 0.0000001;
             String dbValidationFilePath = null;
-            boolean validationCreationParams = false;
             boolean validationSerializationCheck = false;
             int validationParamsSize = 0;
-            // TODO should be false
-            boolean calculateWorkloadStatistics = true;
             long spinnerSleepDuration = 0;
             boolean printHelp = false;
             boolean ignoreScheduledStartTimes = false;
@@ -295,6 +291,7 @@ public class InteractiveWorkloadPerformanceTest
 
             ConsoleAndFileDriverConfiguration configuration = new ConsoleAndFileDriverConfiguration(
                     paramsMap,
+                    mode,
                     name,
                     dbClassName,
                     workloadClassName,
@@ -304,11 +301,9 @@ public class InteractiveWorkloadPerformanceTest
                     timeUnit,
                     resultDirPath,
                     timeCompressionRatio,
-                    validationCreationParams,
                     validationParamsSize,
                     validationSerializationCheck,
                     dbValidationFilePath,
-                    calculateWorkloadStatistics,
                     spinnerSleepDuration,
                     printHelp,
                     ignoreScheduledStartTimes,


### PR DESCRIPTION
- separates the validation properties. New validation properties are introduced:
    - `validate_parameters_size` for the amount of validation parameters to generate
    - `validation_parameters_serialization_check` (true|false) true by default) check after parameter creation whether serialization is successfull
-  Introduce the `mode` property to make OperationMode choice explicit. This replaces the `create_validation_parameters` and  `create_workload_statistics` properties. the The following modes are available:
    - `create_validation`
    - `create_statistics` 
    - `validate_database` 
    - `execute_benchmark`
