### PR TITLE
Fix validation errors

### DIFF
--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery1.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery1.java
@@ -65,11 +65,12 @@ public class LdbcQuery1 extends Operation<List<LdbcQuery1Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put(PERSON_ID, "personIdQ1")
-                .put(FIRST_NAME, "firstName")
-                .put(LIMIT, "limit")
+                .put(PERSON_ID, personIdQ1)
+                .put(FIRST_NAME, firstName)
+                .put(LIMIT, limit)
                 .build();
     }
+
 
     @Override
     public boolean equals( Object o )

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery1.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery1.java
@@ -65,9 +65,9 @@ public class LdbcQuery1 extends Operation<List<LdbcQuery1Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put(PERSON_ID, "getPersonIdQ1")
-                .put(FIRST_NAME, "getFirstName")
-                .put(LIMIT, "getLimit")
+                .put(PERSON_ID, "personIdQ1")
+                .put(FIRST_NAME, "firstName")
+                .put(LIMIT, "limit")
                 .build();
     }
 

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery14Result.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery14Result.java
@@ -2,6 +2,7 @@ package org.ldbcouncil.snb.driver.workloads.interactive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.ldbcouncil.snb.driver.util.ListUtils;
 import org.ldbcouncil.snb.driver.validation.ValidationEquality;
 
 import java.util.Iterator;
@@ -51,6 +52,47 @@ public class LdbcQuery14Result
         return personIdPathsEqual( personIdsInPath, that.personIdsInPath );
     }
 
+    /**
+     * Checks for Iterable<LdbcQuery14Result> if the pathweights and objects are equal.
+     * Note that this is different from the equals() function which compares only 1 object.
+     * @param resultA LdbcQuery14Result iterable expected
+     * @param resultB LdbcQuery14Result iterable actual
+     * @return True if equal, otherwise false
+     */
+    public static boolean resultListEqual( Object resultA, Object resultB )
+    {
+        Iterable<LdbcQuery14Result> iterableResultA = ( Iterable<LdbcQuery14Result> ) resultA;
+        Iterable<LdbcQuery14Result> iterableResultB = ( Iterable<LdbcQuery14Result> ) resultB;
+
+        if (!ListUtils.listsEqual(iterableResultA, iterableResultB))
+            { return false; }
+
+        Iterator<LdbcQuery14Result> resultAIterator = iterableResultA.iterator();
+        Iterator<LdbcQuery14Result> resultBIterator = iterableResultB.iterator();
+
+        while ( resultAIterator.hasNext() )
+        {
+            if ( !resultBIterator.hasNext() )
+                { return false; }
+
+            LdbcQuery14Result resultAQ14Result = resultAIterator.next();
+            LdbcQuery14Result resultBQ14Result = resultBIterator.next();
+            double pathWeightA = resultAQ14Result.getPathWeight();
+            double pathWeightB = resultBQ14Result.getPathWeight();
+
+            if ( !ValidationEquality.doubleEquals( pathWeightA, pathWeightB ))
+            { return false; }
+        }
+        return true;
+    }
+
+    /**
+     * Check if the list of paths is equal. Note that when two paths has the same weight, 
+     * order is unspecified.
+     * @param path1 
+     * @param path2
+     * @return
+     */
     private boolean personIdPathsEqual( Iterable<? extends Number> path1, Iterable<? extends Number> path2 )
     {
         Iterator<? extends Number> path1Iterator = path1.iterator();

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery14Result.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery14Result.java
@@ -114,6 +114,18 @@ public class LdbcQuery14Result
     }
 
     @Override
+    public int hashCode()
+    {
+        int result = Long.valueOf(Double.doubleToLongBits(pathWeight)).hashCode();
+        Iterator i = personIdsInPath.iterator();
+        while (i.hasNext()) {
+            Object obj = i.next();
+            result = 31 * result + (obj==null ? 0 : obj.hashCode());
+        }
+        return result;
+    }
+
+    @Override
     public String toString()
     {
         return "LdbcQuery14Result{" +

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery3Result.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcQuery3Result.java
@@ -39,11 +39,11 @@ public class LdbcQuery3Result {
         return personLastName;
     }
 
-    public long getXCount() {
+    public long getxCount() {
         return xCount;
     }
 
-    public long getYCount() {
+    public long getyCount() {
         return yCount;
     }
 


### PR DESCRIPTION
This PR fixes issues in Q14 Result validation and changes the get functions for Q3 xcount and ycount to fix a bug where the serializer could not find the get functions.
The parametermap for Q1 is also reverted to the old version to support the Cypher implementation