### PR TITLE
Fix insert validation parameter generation

### DIFF
--- a/src/main/java/org/ldbcouncil/snb/driver/Client.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Client.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
-// TODO Validate Workload to work with short reads
 
 public class Client
 {

--- a/src/main/java/org/ldbcouncil/snb/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Workload.java
@@ -70,6 +70,7 @@ public abstract class Workload implements Closeable
             throw new IOException( "Workload may be cleaned up only once" );
         }
         isClosed = true;
+        onClose();
     }
 
     public abstract void onClose();

--- a/src/main/java/org/ldbcouncil/snb/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Workload.java
@@ -4,6 +4,7 @@ import org.ldbcouncil.snb.driver.control.DriverConfiguration;
 import org.ldbcouncil.snb.driver.generator.GeneratorFactory;
 import org.ldbcouncil.snb.driver.validation.ResultsLogValidationTolerances;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-public abstract class Workload
+public abstract class Workload implements Closeable
 {
     public static final long DEFAULT_MAXIMUM_EXPECTED_INTERLEAVE_AS_MILLI = TimeUnit.HOURS.toMillis( 1 );
 
@@ -70,6 +71,8 @@ public abstract class Workload
         }
         isClosed = true;
     }
+
+    public abstract void onClose();
 
     public final WorkloadStreams streams( GeneratorFactory gf, boolean hasDbConnected ) throws WorkloadException
     {

--- a/src/main/java/org/ldbcouncil/snb/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Workload.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public abstract class Workload
@@ -122,7 +123,7 @@ public abstract class Workload
         return DEFAULT_MAXIMUM_EXPECTED_INTERLEAVE_AS_MILLI;
     }
 
-    public abstract int enabledValidationOperations();
+    public abstract Set<Class> enabledValidationOperations();
 
     public interface DbValidationParametersFilter
     {

--- a/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
@@ -123,9 +123,8 @@ public class CreateValidationParamsMode implements ClientMode<Object>
     @Override
     public Object startExecutionAndAwaitCompletion() throws ClientException
     {
-        try ( Db db = database )
+        try (Workload w = workload; Db db = database )
         {
-            Workload w = workload;
             File validationFileToGenerate =
                     new File( controlService.configuration().databaseValidationFilePath() );
                 

--- a/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/CreateValidationParamsMode.java
@@ -137,8 +137,7 @@ public class CreateValidationParamsMode implements ClientMode<Object>
             Iterator<ValidationParam> validationParamsGenerator = new ValidationParamsGenerator(
                     db,
                     w.dbValidationParametersFilter( validationSetSize ),
-                    timeMappedOperations,
-                    validationSetSize
+                    timeMappedOperations
             );
             List<ValidationParam> validationParams = ImmutableList.copyOf(validationParamsGenerator);
             ValidationParamsToJson validationParamsAsJson = new ValidationParamsToJson(

--- a/src/main/java/org/ldbcouncil/snb/driver/client/ValidateDatabaseMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/ValidateDatabaseMode.java
@@ -76,9 +76,8 @@ public class ValidateDatabaseMode implements ClientMode<DbValidationResult>
     @Override
     public DbValidationResult startExecutionAndAwaitCompletion() throws ClientException
     {
-        try ( Db db = database )
+        try (Workload w = workload;  Db db = database )
         {
-            Workload w = workload; 
             File validationParamsFile = new File( controlService.configuration().databaseValidationFilePath() );
 
             loggingService.info(

--- a/src/main/java/org/ldbcouncil/snb/driver/generator/OperationStreamBuffer.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/generator/OperationStreamBuffer.java
@@ -1,65 +1,24 @@
 package org.ldbcouncil.snb.driver.generator;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.ldbcouncil.snb.driver.Operation;
-import org.ldbcouncil.snb.driver.csv.ParquetLoader;
-import org.ldbcouncil.snb.driver.workloads.interactive.RunnableOperationStreamBatchLoader;
 
 
 public class OperationStreamBuffer implements Iterator<Iterator<Operation>>{
     
     private final BlockingQueue<Iterator<Operation>> blockingQueue;
-    private final ParquetLoader loader;
-    private final GeneratorFactory gf;
-    private final int numThreads;
-    private final long batchSize;
-    private final Set<Class<? extends Operation>> enabledUpdateOperationTypes;
-    private final File updatesDir;
 
     private boolean isEmpty = false;
 
-    private Thread runnableBatchLoader;
-
     public OperationStreamBuffer(
-        ParquetLoader loader,
-        File updatesDir,
-        GeneratorFactory gf,
-        long batchSize,
-        int numThreads,
-        Set<Class<? extends Operation>> enabledUpdateOperationTypes
+        BlockingQueue<Iterator<Operation>> blockingQueue
     )
     {
-        this.blockingQueue = new LinkedBlockingQueue<>(numThreads);
-        this.loader = loader;
-        this.updatesDir = updatesDir;
-        this.gf = gf;
-        this.enabledUpdateOperationTypes = enabledUpdateOperationTypes;
-        this.batchSize = batchSize;
-        this.numThreads = numThreads;
-    }
-
-    // Fills up the buffer
-    public void init()
-    {
-        Runnable batch = new RunnableOperationStreamBatchLoader(
-            loader,
-            gf,
-            updatesDir,
-            blockingQueue,
-            enabledUpdateOperationTypes,
-            batchSize,
-            numThreads
-        );
-        // Start the thread
-        runnableBatchLoader = new Thread(batch);
-        runnableBatchLoader.start();
+        this.blockingQueue = blockingQueue;
     }
 
     @Override
@@ -84,7 +43,6 @@ public class OperationStreamBuffer implements Iterator<Iterator<Operation>>{
         {
             return null;
         }
-
     }
 
     @Override

--- a/src/main/java/org/ldbcouncil/snb/driver/validation/ValidationParamsToJson.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/validation/ValidationParamsToJson.java
@@ -55,25 +55,28 @@ public class ValidationParamsToJson
             catch (IOException e )
             {
                 throw new GeneratorException(
-                        format( ""
-                                + "Error marshalling serialized validationparam\n"
-                                + "validationParam: %s\n",
-                                validationParams ),
-                        e );
+                    format( ""
+                        + "Error marshalling serialized validationparam\n"
+                        + "validationParam: %s\n",
+                        validationParams ), e
+                    );
             }
             if (!deserializedValidationParameters.equals( validationParams ) )
             {
                 throw new GeneratorException(
-                        format( ""
-                                + "Deserialized validation parameters and original validation parameters do not equal\n"
-                                + "validationParams: %s\n"
-                                + "serializedValidationParam: %s\n"
-                                + "deserializedValidationParameters: %s",
-                                validationParams, serializedValidationParams, deserializedValidationParameters )
+                    format( ""
+                        + "Deserialized validation parameters and original validation parameters do not equal\n"
+                        + "validationParams: %s\n"
+                        + "serializedValidationParam: %s\n"
+                        + "deserializedValidationParameters: %s",
+                        validationParams,
+                        serializedValidationParams,
+                        deserializedValidationParameters
+                    )
                 );
             }
         }
 
-        OBJECT_MAPPER.writeValue(outputFile, validationParams);
+        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(outputFile, validationParams);
     }
 }

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -597,9 +597,13 @@ public class LdbcSnbInteractiveWorkload extends Workload
     }
 
     @Override
-    public int enabledValidationOperations()
+    public Set<Class> enabledValidationOperations()
     {
-        return enabledLongReadOperationTypes.size() + enabledUpdateOperationTypes.size() + enabledShortReadOperationTypes.size();
+        Set<Class> enabledOperations = new HashSet<>();
+        enabledOperations.addAll(enabledLongReadOperationTypes);
+        enabledOperations.addAll(enabledUpdateOperationTypes);
+        enabledOperations.addAll(enabledShortReadOperationTypes);
+        return enabledOperations;
     }
 
     @Override

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -70,6 +70,12 @@ public class LdbcSnbInteractiveWorkload extends Workload
     }
 
     @Override
+    public void onClose()
+    {
+
+    }
+
+    @Override
     public void onInit( Map<String,String> params ) throws WorkloadException
     {
         List<String> compulsoryKeys = Lists.newArrayList();

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -582,7 +582,6 @@ public class LdbcSnbInteractiveWorkload extends Workload
         return new LdbcSnbInteractiveDbValidationParametersFilter(
             remainingRequiredResultsPerType,
             // Writes are required to determine short reads operations to inject
-            enabledWriteOperationTypes,
             enabledShortReadOperationTypes
         );
     }

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -72,7 +72,7 @@ public class LdbcSnbInteractiveWorkload extends Workload
     @Override
     public void onClose()
     {
-
+        runnableBatchLoaderThread.interrupt();
     }
 
     @Override

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/RunnableOperationStreamBatchLoader.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/RunnableOperationStreamBatchLoader.java
@@ -18,7 +18,7 @@ import org.ldbcouncil.snb.driver.generator.EventStreamReader;
 import org.ldbcouncil.snb.driver.generator.GeneratorFactory;
 import org.ldbcouncil.snb.driver.util.Tuple2;
 
-public class RunnableOperationStreamBatchLoader implements Runnable {
+public class RunnableOperationStreamBatchLoader extends Thread {
     
     private final ParquetLoader loader;
     private final int numThreads;
@@ -50,6 +50,7 @@ public class RunnableOperationStreamBatchLoader implements Runnable {
     /**
      * Loads the operation streams into the LinkedBlockingDeque
      */
+    @Override
     public void run()
     {
         BatchedOperationStreamReader updateOperationStream = new BatchedOperationStreamReader(loader);
@@ -78,7 +79,7 @@ public class RunnableOperationStreamBatchLoader implements Runnable {
             }
 
             // Loop until interrupt or no operations left to load
-            while (!Thread.currentThread().interrupted()) {
+            while (!Thread.interrupted()) {
                 List<Iterator<Operation>> newBatch = loadNextBatch(
                     updateOperationStream,
                     offset,

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/RunnableOperationStreamBatchLoader.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/RunnableOperationStreamBatchLoader.java
@@ -78,7 +78,7 @@ public class RunnableOperationStreamBatchLoader implements Runnable {
             }
 
             // Loop until interrupt or no operations left to load
-            while (true) {
+            while (!Thread.currentThread().interrupted()) {
                 List<Iterator<Operation>> newBatch = loadNextBatch(
                     updateOperationStream,
                     offset,

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
@@ -12,13 +12,13 @@ import org.ldbcouncil.snb.driver.util.Tuple;
 import org.ldbcouncil.snb.driver.util.Tuple2;
 import org.ldbcouncil.snb.driver.util.Tuple3;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class SimpleWorkload extends Workload
 {
@@ -64,8 +64,8 @@ public class SimpleWorkload extends Workload
     }
 
     @Override
-    public int enabledValidationOperations(){
-        return 0;
+    public Set<Class> enabledValidationOperations(){
+        return Collections.emptySet();
     }
 
     @Override

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/simple/SimpleWorkload.java
@@ -69,6 +69,13 @@ public class SimpleWorkload extends Workload
     }
 
     @Override
+    public void onClose()
+    {
+
+    }
+
+ 
+    @Override
     public WorkloadStreams getStreams( GeneratorFactory gf, boolean hasDbConnected ) throws WorkloadException
     {
         long workloadStartTimeAsMilli = 0;

--- a/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
@@ -21,11 +21,13 @@ import org.ldbcouncil.snb.driver.workloads.dummy.TimedNamedOperation3Factory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -901,9 +903,9 @@ public class WorkloadStreamsTest
         }
 
         @Override
-        public int enabledValidationOperations()
+        public Set<Class> enabledValidationOperations()
         {
-            return 0;
+            return Collections.emptySet();
         }
 
         @Override

--- a/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/WorkloadStreamsTest.java
@@ -909,6 +909,12 @@ public class WorkloadStreamsTest
         }
 
         @Override
+        public void onClose()
+        {
+    
+        }
+      
+        @Override
         public Class<? extends Operation> getOperationClass()
         {
             return Operation.class;

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
@@ -7,9 +7,10 @@ import org.ldbcouncil.snb.driver.WorkloadException;
 import org.ldbcouncil.snb.driver.WorkloadStreams;
 import org.ldbcouncil.snb.driver.generator.GeneratorFactory;
 
-import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class DummyWorkload extends Workload
 {
@@ -37,8 +38,8 @@ public class DummyWorkload extends Workload
     }
 
     @Override
-    public int enabledValidationOperations(){
-        return 0;
+    public Set<Class> enabledValidationOperations(){
+        return Collections.emptySet();
     }
 
     @Override

--- a/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/workloads/dummy/DummyWorkload.java
@@ -55,6 +55,12 @@ public class DummyWorkload extends Workload
     }
 
     @Override
+    public void onClose()
+    {
+
+    }
+
+    @Override
     public void onInit( Map<String,String> params ) throws WorkloadException
     {
     }


### PR DESCRIPTION
- Short queries are generated always after an insert and does not count toward specified validation parameter count
- Add option to skip queries during validation
- Solved bug where driver would not close after workload is done