### PR TITLE
Validation: check 5% delay per query type instead of 5% of total operation count

### DIFF
--- a/src/main/java/org/ldbcouncil/snb/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/Workload.java
@@ -40,7 +40,8 @@ public abstract class Workload implements Closeable
                          : Math.round( configuration.operationCount() * toleratedExcessiveDelayCountPercentage );
         return new ResultsLogValidationTolerances(
                 excessiveDelayThresholdAsMilli,
-                toleratedExcessiveDelayCount
+                toleratedExcessiveDelayCount,
+                toleratedExcessiveDelayCountPercentage
         );
     }
 

--- a/src/main/java/org/ldbcouncil/snb/driver/client/ExecuteWorkloadMode.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/client/ExecuteWorkloadMode.java
@@ -443,6 +443,9 @@ public class ExecuteWorkloadMode implements ClientMode<Object>
                     ResultsLogValidator resultsLogValidator = new ResultsLogValidator();
                     ResultsLogValidationTolerances resultsLogValidationTolerances =
                             workload.resultsLogValidationTolerances( controlService.configuration(), warmup );
+
+
+                    
                     ResultsLogValidationSummary resultsLogValidationSummary = resultsLogValidator.compute(
                             resultsDirectory.getOrCreateResultsLogFile( warmup ),
                             resultsLogValidationTolerances.excessiveDelayThresholdAsMilli()
@@ -460,7 +463,8 @@ public class ExecuteWorkloadMode implements ClientMode<Object>
                     ResultsLogValidationResult validationResult = resultsLogValidator.validate(
                             resultsLogValidationSummary,
                             resultsLogValidationTolerances,
-                            controlService.configuration().recordDelayedOperations()
+                            controlService.configuration().recordDelayedOperations(),
+                            workloadResults
                     );
                     loggingService.info( validationResult.getScheduleAuditResult(
                         controlService.configuration().recordDelayedOperations()

--- a/src/main/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTolerances.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTolerances.java
@@ -9,13 +9,16 @@ public class ResultsLogValidationTolerances
 {
     private final long excessiveDelayThresholdAsMilli;
     private final long toleratedExcessiveDelayCount;
+    private final double toleratedExcessiveDelayCountPercentage;
 
     public ResultsLogValidationTolerances(
         long excessiveDelayThresholdAsMilli,
-        long toleratedExcessiveDelayCount)
+        long toleratedExcessiveDelayCount,
+        double toleratedExcessiveDelayCountPercentage)
     {
         this.excessiveDelayThresholdAsMilli = excessiveDelayThresholdAsMilli;
         this.toleratedExcessiveDelayCount = toleratedExcessiveDelayCount;
+        this.toleratedExcessiveDelayCountPercentage = toleratedExcessiveDelayCountPercentage;
     }
 
     public long excessiveDelayThresholdAsMilli()
@@ -26,5 +29,10 @@ public class ResultsLogValidationTolerances
     public long toleratedExcessiveDelayCount()
     {
         return toleratedExcessiveDelayCount;
+    }
+
+    public double toleratedExcessiveDelayCountPercentage()
+    {
+        return toleratedExcessiveDelayCountPercentage;
     }
 }

--- a/src/test/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTest.java
@@ -36,98 +36,101 @@ public class ResultsLogValidationTest
     @TempDir
     public File temporaryFolder;
 
-    @Test
-    public void shouldPassValidationWhenResultsAreGood()
-    {
-        long excessiveDelayThresholdAsMilli = 10;
-        boolean recordDelayedOperations = false;
-        long excessiveDelayCount = 10;
-        Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
-        excessiveDelayCountPerType.put( "A", 1l );
-        excessiveDelayCountPerType.put( "B", 2l );
-        excessiveDelayCountPerType.put( "C", 3l );
-        long minDelayAsMilli = 0;
-        long maxDelayAsMilli = 0;
-        long meanDelayAsMilli = 0;
-        Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
-        Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
-        Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
-        ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
-                excessiveDelayThresholdAsMilli,
-                excessiveDelayCount,
-                excessiveDelayCountPerType,
-                minDelayAsMilli,
-                maxDelayAsMilli,
-                meanDelayAsMilli,
-                minDelayAsMilliPerType,
-                maxDelayAsMilliPerType,
-                meanDelayAsMilliPerType
-        );
+    // @Test
+    // public void shouldPassValidationWhenResultsAreGood()
+    // {
+    //     long excessiveDelayThresholdAsMilli = 10;
+    //     boolean recordDelayedOperations = false;
+    //     long excessiveDelayCount = 10;
+    //     double toleratedExcessiveDelayCountPercentage = 0.05d;
+    //     Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
+    //     excessiveDelayCountPerType.put( "A", 1l );
+    //     excessiveDelayCountPerType.put( "B", 2l );
+    //     excessiveDelayCountPerType.put( "C", 3l );
+    //     long minDelayAsMilli = 0;
+    //     long maxDelayAsMilli = 0;
+    //     long meanDelayAsMilli = 0;
+    //     Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
+    //     Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
+    //     Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
+    //     ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
+    //             excessiveDelayThresholdAsMilli,
+    //             excessiveDelayCount,
+    //             excessiveDelayCountPerType,
+    //             minDelayAsMilli,
+    //             maxDelayAsMilli,
+    //             meanDelayAsMilli,
+    //             minDelayAsMilliPerType,
+    //             maxDelayAsMilliPerType,
+    //             meanDelayAsMilliPerType
+    //     );
 
-        long toleratedExcessiveDelayCount = excessiveDelayCount;
-        Map<String,Long> toleratedExcessiveDelayCountPerType = new HashMap<>();
-        toleratedExcessiveDelayCountPerType.put( "A", excessiveDelayCountPerType.get( "A" ) );
-        toleratedExcessiveDelayCountPerType.put( "B", excessiveDelayCountPerType.get( "B" ) );
-        toleratedExcessiveDelayCountPerType.put( "C", excessiveDelayCountPerType.get( "C" ) );
-        ResultsLogValidator validator = new ResultsLogValidator();
-        ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
-                excessiveDelayThresholdAsMilli,
-                toleratedExcessiveDelayCount
-        );
-        ResultsLogValidationResult result = validator.validate(
-                summary,
-                tolerances,
-                recordDelayedOperations
-        );
-        assertTrue( result.isSuccessful(), result.toString() );
-    }
+    //     long toleratedExcessiveDelayCount = excessiveDelayCount;
+    //     Map<String,Long> toleratedExcessiveDelayCountPerType = new HashMap<>();
+    //     toleratedExcessiveDelayCountPerType.put( "A", excessiveDelayCountPerType.get( "A" ) );
+    //     toleratedExcessiveDelayCountPerType.put( "B", excessiveDelayCountPerType.get( "B" ) );
+    //     toleratedExcessiveDelayCountPerType.put( "C", excessiveDelayCountPerType.get( "C" ) );
+    //     ResultsLogValidator validator = new ResultsLogValidator();
+    //     ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
+    //             excessiveDelayThresholdAsMilli,
+    //             toleratedExcessiveDelayCount,
+    //             toleratedExcessiveDelayCountPercentage
+    //     );
+    //     ResultsLogValidationResult result = validator.validate(
+    //             summary,
+    //             tolerances,
+    //             recordDelayedOperations,
+    //             summary
+    //     );
+    //     assertTrue( result.isSuccessful(), result.toString() );
+    // }
 
-    @Test
-    public void shouldFailValidationWhenExcessiveDelayCountIsExceeded()
-    {
-        boolean recordDelayedOperations = true;
-        long excessiveDelayThresholdAsMilli = 10;
-        long excessiveDelayCount = 10;
-        Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
-        excessiveDelayCountPerType.put( "A", 1l );
-        excessiveDelayCountPerType.put( "B", 2l );
-        excessiveDelayCountPerType.put( "C", 3l );
-        long minDelayAsMilli = 0;
-        long maxDelayAsMilli = 0;
-        long meanDelayAsMilli = 0;
-        Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
-        Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
-        Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
-        ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
-                excessiveDelayThresholdAsMilli,
-                excessiveDelayCount,
-                excessiveDelayCountPerType,
-                minDelayAsMilli,
-                maxDelayAsMilli,
-                meanDelayAsMilli,
-                minDelayAsMilliPerType,
-                maxDelayAsMilliPerType,
-                meanDelayAsMilliPerType
-        );
+    // @Test
+    // public void shouldFailValidationWhenExcessiveDelayCountIsExceeded()
+    // {
+    //     boolean recordDelayedOperations = true;
+    //     long excessiveDelayThresholdAsMilli = 10;
+    //     long excessiveDelayCount = 10;
+    //     Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
+    //     excessiveDelayCountPerType.put( "A", 1l );
+    //     excessiveDelayCountPerType.put( "B", 2l );
+    //     excessiveDelayCountPerType.put( "C", 3l );
+    //     long minDelayAsMilli = 0;
+    //     long maxDelayAsMilli = 0;
+    //     long meanDelayAsMilli = 0;
+    //     Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
+    //     Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
+    //     Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
+    //     ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
+    //             excessiveDelayThresholdAsMilli,
+    //             excessiveDelayCount,
+    //             excessiveDelayCountPerType,
+    //             minDelayAsMilli,
+    //             maxDelayAsMilli,
+    //             meanDelayAsMilli,
+    //             minDelayAsMilliPerType,
+    //             maxDelayAsMilliPerType,
+    //             meanDelayAsMilliPerType
+    //     );
 
-        long toleratedExcessiveDelayCount = excessiveDelayCount - 1;
-        ResultsLogValidator validator = new ResultsLogValidator();
-        ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
-                excessiveDelayThresholdAsMilli,
-                toleratedExcessiveDelayCount
-        );
-        ResultsLogValidationResult result = validator.validate(
-                summary,
-                tolerances,
-                recordDelayedOperations
-        );
-        assertFalse( result.isSuccessful(), result.toString() );
-        assertThat(
-                result.toString(),
-                result.errors().get( 0 ).errorType(),
-                equalTo( ResultsLogValidationResult.ValidationErrorType.TOO_MANY_LATE_OPERATIONS )
-        );
-    }
+    //     long toleratedExcessiveDelayCount = excessiveDelayCount - 1;
+    //     ResultsLogValidator validator = new ResultsLogValidator();
+    //     ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
+    //             excessiveDelayThresholdAsMilli,
+    //             toleratedExcessiveDelayCount
+    //     );
+    //     ResultsLogValidationResult result = validator.validate(
+    //             summary,
+    //             tolerances,
+    //             recordDelayedOperations
+    //     );
+    //     assertFalse( result.isSuccessful(), result.toString() );
+    //     assertThat(
+    //             result.toString(),
+    //             result.errors().get( 0 ).errorType(),
+    //             equalTo( ResultsLogValidationResult.ValidationErrorType.TOO_MANY_LATE_OPERATIONS )
+    //     );
+    // }
 
     @Test
     public void shouldReturnExpectedSummaryWhenComputedThenSerializedAndMarshaled() throws IOException

--- a/src/test/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/validation/ResultsLogValidationTest.java
@@ -2,6 +2,8 @@ package org.ldbcouncil.snb.driver.validation;
 
 import com.google.common.collect.Lists;
 import org.ldbcouncil.snb.driver.csv.simple.SimpleCsvFileWriter;
+import org.ldbcouncil.snb.driver.runtime.metrics.OperationMetricsSnapshot;
+import org.ldbcouncil.snb.driver.runtime.metrics.WorkloadResultsSnapshot;
 import org.ldbcouncil.snb.driver.util.Tuple;
 import org.ldbcouncil.snb.driver.util.Tuple2;
 import org.junit.jupiter.api.Test;
@@ -9,9 +11,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,104 +38,92 @@ public class ResultsLogValidationTest
             Tuple.tuple2( "D", 1000l ),
             Tuple.tuple2( "E", 10000l )
     );
-    @TempDir
-    public File temporaryFolder;
+    
+    private ResultsLogValidationResult runValidation(boolean recordDelayedOperations, int toleratedExcessiveDelayCount)
+    {
+        long excessiveDelayThresholdAsMilli = 10;
+        long excessiveDelayCount = 10;
+        double toleratedExcessiveDelayCountPercentage = 0.05d;
+        Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
+        excessiveDelayCountPerType.put( "A", 1l );
+        excessiveDelayCountPerType.put( "B", 2l );
+        excessiveDelayCountPerType.put( "C", 3l );
+        long minDelayAsMilli = 0;
+        long maxDelayAsMilli = 0;
+        long meanDelayAsMilli = 0;
+        Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
+        Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
+        Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
+        ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
+                excessiveDelayThresholdAsMilli,
+                excessiveDelayCount,
+                excessiveDelayCountPerType,
+                minDelayAsMilli,
+                maxDelayAsMilli,
+                meanDelayAsMilli,
+                minDelayAsMilliPerType,
+                maxDelayAsMilliPerType,
+                meanDelayAsMilliPerType
+        );
 
-    // @Test
-    // public void shouldPassValidationWhenResultsAreGood()
-    // {
-    //     long excessiveDelayThresholdAsMilli = 10;
-    //     boolean recordDelayedOperations = false;
-    //     long excessiveDelayCount = 10;
-    //     double toleratedExcessiveDelayCountPercentage = 0.05d;
-    //     Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
-    //     excessiveDelayCountPerType.put( "A", 1l );
-    //     excessiveDelayCountPerType.put( "B", 2l );
-    //     excessiveDelayCountPerType.put( "C", 3l );
-    //     long minDelayAsMilli = 0;
-    //     long maxDelayAsMilli = 0;
-    //     long meanDelayAsMilli = 0;
-    //     Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
-    //     Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
-    //     Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
-    //     ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
-    //             excessiveDelayThresholdAsMilli,
-    //             excessiveDelayCount,
-    //             excessiveDelayCountPerType,
-    //             minDelayAsMilli,
-    //             maxDelayAsMilli,
-    //             meanDelayAsMilli,
-    //             minDelayAsMilliPerType,
-    //             maxDelayAsMilliPerType,
-    //             meanDelayAsMilliPerType
-    //     );
+        OperationMetricsSnapshot operationA = new OperationMetricsSnapshot("A",TimeUnit.MILLISECONDS, 1, null);
+        OperationMetricsSnapshot operationB = new OperationMetricsSnapshot("B",TimeUnit.MILLISECONDS, 1, null);
+        OperationMetricsSnapshot operationC = new OperationMetricsSnapshot("C",TimeUnit.MILLISECONDS, 1, null);
+        List<OperationMetricsSnapshot> metrics = new ArrayList<>(
+            Arrays.asList(
+            operationA, operationB, operationC
+        ));
 
-    //     long toleratedExcessiveDelayCount = excessiveDelayCount;
-    //     Map<String,Long> toleratedExcessiveDelayCountPerType = new HashMap<>();
-    //     toleratedExcessiveDelayCountPerType.put( "A", excessiveDelayCountPerType.get( "A" ) );
-    //     toleratedExcessiveDelayCountPerType.put( "B", excessiveDelayCountPerType.get( "B" ) );
-    //     toleratedExcessiveDelayCountPerType.put( "C", excessiveDelayCountPerType.get( "C" ) );
-    //     ResultsLogValidator validator = new ResultsLogValidator();
-    //     ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
-    //             excessiveDelayThresholdAsMilli,
-    //             toleratedExcessiveDelayCount,
-    //             toleratedExcessiveDelayCountPercentage
-    //     );
-    //     ResultsLogValidationResult result = validator.validate(
-    //             summary,
-    //             tolerances,
-    //             recordDelayedOperations,
-    //             summary
-    //     );
-    //     assertTrue( result.isSuccessful(), result.toString() );
-    // }
+        WorkloadResultsSnapshot workloadResults = new WorkloadResultsSnapshot(
+            metrics,
+            1,
+            10,
+            3,
+            TimeUnit.MILLISECONDS
+        );
 
-    // @Test
-    // public void shouldFailValidationWhenExcessiveDelayCountIsExceeded()
-    // {
-    //     boolean recordDelayedOperations = true;
-    //     long excessiveDelayThresholdAsMilli = 10;
-    //     long excessiveDelayCount = 10;
-    //     Map<String,Long> excessiveDelayCountPerType = new HashMap<>();
-    //     excessiveDelayCountPerType.put( "A", 1l );
-    //     excessiveDelayCountPerType.put( "B", 2l );
-    //     excessiveDelayCountPerType.put( "C", 3l );
-    //     long minDelayAsMilli = 0;
-    //     long maxDelayAsMilli = 0;
-    //     long meanDelayAsMilli = 0;
-    //     Map<String,Long> minDelayAsMilliPerType = new HashMap<>();
-    //     Map<String,Long> maxDelayAsMilliPerType = new HashMap<>();
-    //     Map<String,Long> meanDelayAsMilliPerType = new HashMap<>();
-    //     ResultsLogValidationSummary summary = new ResultsLogValidationSummary(
-    //             excessiveDelayThresholdAsMilli,
-    //             excessiveDelayCount,
-    //             excessiveDelayCountPerType,
-    //             minDelayAsMilli,
-    //             maxDelayAsMilli,
-    //             meanDelayAsMilli,
-    //             minDelayAsMilliPerType,
-    //             maxDelayAsMilliPerType,
-    //             meanDelayAsMilliPerType
-    //     );
+        Map<String,Long> toleratedExcessiveDelayCountPerType = new HashMap<>();
+        toleratedExcessiveDelayCountPerType.put( "A", excessiveDelayCountPerType.get( "A" ) );
+        toleratedExcessiveDelayCountPerType.put( "B", excessiveDelayCountPerType.get( "B" ) );
+        toleratedExcessiveDelayCountPerType.put( "C", excessiveDelayCountPerType.get( "C" ) );
+        ResultsLogValidator validator = new ResultsLogValidator();
+        ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
+                excessiveDelayThresholdAsMilli,
+                toleratedExcessiveDelayCount,
+                toleratedExcessiveDelayCountPercentage
+        );
+        ResultsLogValidationResult result = validator.validate(
+                summary,
+                tolerances,
+                recordDelayedOperations,
+                workloadResults
+        );
+        return result;
+    }
+    
+    @Test
+    public void shouldPassValidationWhenResultsAreGood()
+    {
+        boolean recordDelayedOperations = false;
+        int toleratedExcessiveDelayCount = 10;
+        ResultsLogValidationResult result = runValidation(recordDelayedOperations, toleratedExcessiveDelayCount);
+        assertTrue( result.isSuccessful(), result.toString() );
+    }
 
-    //     long toleratedExcessiveDelayCount = excessiveDelayCount - 1;
-    //     ResultsLogValidator validator = new ResultsLogValidator();
-    //     ResultsLogValidationTolerances tolerances = new ResultsLogValidationTolerances(
-    //             excessiveDelayThresholdAsMilli,
-    //             toleratedExcessiveDelayCount
-    //     );
-    //     ResultsLogValidationResult result = validator.validate(
-    //             summary,
-    //             tolerances,
-    //             recordDelayedOperations
-    //     );
-    //     assertFalse( result.isSuccessful(), result.toString() );
-    //     assertThat(
-    //             result.toString(),
-    //             result.errors().get( 0 ).errorType(),
-    //             equalTo( ResultsLogValidationResult.ValidationErrorType.TOO_MANY_LATE_OPERATIONS )
-    //     );
-    // }
+    @Test
+    public void shouldFailValidationWhenExcessiveDelayCountIsExceeded()
+    {
+        boolean recordDelayedOperations = true;
+        int toleratedExcessiveDelayCount = 9;
+        ResultsLogValidationResult result = runValidation(recordDelayedOperations, toleratedExcessiveDelayCount);
+        
+        assertFalse( result.isSuccessful(), result.toString() );
+        assertThat(
+                result.toString(),
+                result.errors().get( 0 ).errorType(),
+                equalTo( ResultsLogValidationResult.ValidationErrorType.TOO_MANY_LATE_OPERATIONS )
+        );
+    }
 
     @Test
     public void shouldReturnExpectedSummaryWhenComputedThenSerializedAndMarshaled() throws IOException
@@ -161,11 +154,11 @@ public class ResultsLogValidationTest
     }
 
     @Test
-    public void shouldReturnExpectedSummaryWhenValidatedFromFile() throws IOException, ValidationException
+    public void shouldReturnExpectedSummaryWhenValidatedFromFile(@TempDir File temporaryFolder) throws IOException, ValidationException
     {
         // Given
         long excessiveDelayThreshold = 5;
-        File file = new File(this.temporaryFolder, "output.csv");
+        File file = new File(temporaryFolder, "output.csv");
 
         try ( SimpleCsvFileWriter writer =
                       new SimpleCsvFileWriter( file, SimpleCsvFileWriter.DEFAULT_COLUMN_SEPARATOR, false ) )


### PR DESCRIPTION
For SNB Interactive, the total allowed delay count of 5% will be enforced per query instead over all executed operations. This PR changes the validator to check if the total delayed operations is below 5% of executed operations of that query type.