### PR TITLE
Move temporal parameter check to merging iterator

### DIFF
--- a/src/main/java/org/ldbcouncil/snb/driver/generator/MergingGenerator.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/generator/MergingGenerator.java
@@ -26,8 +26,12 @@ public class MergingGenerator<FROM_GENERATE_TYPE_1, FROM_GENERATE_TYPE_2, TO_GEN
     protected TO_GENERATE_TYPE doNext() throws GeneratorException
     {
         if ( original1.hasNext() && original2.hasNext() )
-        { return mergeFun.apply( original1.next(), original2.next() ); }
+        {
+            return mergeFun.apply( original1.next(), original2.next() );
+        }
         else
-        { return null; }
+        {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/ldbcouncil/snb/driver/generator/MergingGeneratorWithSkip.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/generator/MergingGeneratorWithSkip.java
@@ -1,0 +1,64 @@
+package org.ldbcouncil.snb.driver.generator;
+
+import org.ldbcouncil.snb.driver.util.Function2;
+
+import java.util.Iterator;
+
+/**
+ * Merging Generator which skips null results for the second FROM_GENERATE_TYPE_2. Find
+ * suitable FROM_GENERATE_TYPE_1 and FROM_GENERATE_TYPE_2 combinations.
+ */
+public class MergingGeneratorWithSkip<FROM_GENERATE_TYPE_1, FROM_GENERATE_TYPE_2, TO_GENERATE_TYPE>
+        extends Generator<TO_GENERATE_TYPE>
+{
+    private final int MAX_SKIP = 100;
+    private final Iterator<FROM_GENERATE_TYPE_1> original1;
+    private final Iterator<FROM_GENERATE_TYPE_2> original2;
+    private final Function2<FROM_GENERATE_TYPE_1,FROM_GENERATE_TYPE_2,TO_GENERATE_TYPE,RuntimeException> mergeFun;
+    private final Function2<FROM_GENERATE_TYPE_1,FROM_GENERATE_TYPE_2,TO_GENERATE_TYPE,RuntimeException> checkFun;
+
+    public MergingGeneratorWithSkip(
+            Iterator<FROM_GENERATE_TYPE_1> original1,
+            Iterator<FROM_GENERATE_TYPE_2> original2,
+            Function2<FROM_GENERATE_TYPE_1,FROM_GENERATE_TYPE_2,TO_GENERATE_TYPE,RuntimeException> mergeFun,
+            Function2<FROM_GENERATE_TYPE_1, FROM_GENERATE_TYPE_2, TO_GENERATE_TYPE, RuntimeException> checkFun)
+    {
+        this.original1 = original1;
+        this.original2 = original2;
+        this.mergeFun = mergeFun;
+        this.checkFun = checkFun;
+    }
+
+    @Override
+    protected TO_GENERATE_TYPE doNext() throws GeneratorException
+    {
+        TO_GENERATE_TYPE operation = null;
+        FROM_GENERATE_TYPE_1 type1;
+        FROM_GENERATE_TYPE_2 type2;
+        int skipped = 0;
+        if ( original1.hasNext() && original2.hasNext() )
+        {
+            type1 = original1.next();
+            type2 = original2.next();
+        }
+        else
+        {
+            return null;
+        }
+
+        while (original2.hasNext() && operation == null && skipped < MAX_SKIP)
+        {
+            operation = checkFun.apply( type1, type2 );
+            type2 = original2.next();
+            skipped++;
+        }
+
+        if (skipped > MAX_SKIP)
+        {
+            return null;
+        }
+
+        operation = mergeFun.apply( type1, type2 );
+        return operation;
+    }
+}

--- a/src/main/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunner.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/runtime/WorkloadRunner.java
@@ -343,8 +343,7 @@ public class WorkloadRunner
                     errorReporter,
                     asynchronousStream,
                     executorForAsynchronous,
-                    completionTimeWriterForAsynchronous,
-                    completionTimeService
+                    completionTimeWriterForAsynchronous
             );
             this.stateRef = new AtomicReference<>( WorkloadRunnerThreadState.NOT_STARTED );
         }

--- a/src/main/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorService.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorService.java
@@ -2,7 +2,6 @@ package org.ldbcouncil.snb.driver.runtime.executor;
 
 import org.ldbcouncil.snb.driver.WorkloadStreams.WorkloadStreamDefinition;
 import org.ldbcouncil.snb.driver.runtime.ConcurrentErrorReporter;
-import org.ldbcouncil.snb.driver.runtime.coordination.CompletionTimeReader;
 import org.ldbcouncil.snb.driver.runtime.coordination.CompletionTimeWriter;
 
 import java.util.concurrent.TimeUnit;
@@ -25,9 +24,7 @@ public class OperationStreamExecutorService
             ConcurrentErrorReporter errorReporter,
             WorkloadStreamDefinition streamDefinition,
             OperationExecutor operationExecutor,
-            CompletionTimeWriter completionTimeWriter,
-            CompletionTimeReader completionTimeReader
-             )
+            CompletionTimeWriter completionTimeWriter )
     {
         this.errorReporter = errorReporter;
         if ( streamDefinition.dependencyOperations().hasNext() || streamDefinition.nonDependencyOperations().hasNext() )
@@ -38,8 +35,7 @@ public class OperationStreamExecutorService
                     streamDefinition,
                     hasFinished,
                     forceThreadToTerminate,
-                    completionTimeWriter,
-                    completionTimeReader );
+                    completionTimeWriter );
         }
         else
         {

--- a/src/main/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorServiceThread.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorServiceThread.java
@@ -3,7 +3,6 @@ package org.ldbcouncil.snb.driver.runtime.executor;
 import org.ldbcouncil.snb.driver.Operation;
 import org.ldbcouncil.snb.driver.WorkloadStreams.WorkloadStreamDefinition;
 import org.ldbcouncil.snb.driver.runtime.ConcurrentErrorReporter;
-import org.ldbcouncil.snb.driver.runtime.coordination.CompletionTimeReader;
 import org.ldbcouncil.snb.driver.runtime.coordination.CompletionTimeWriter;
 import org.ldbcouncil.snb.driver.runtime.scheduling.Spinner;
 
@@ -24,9 +23,7 @@ class OperationStreamExecutorServiceThread extends Thread
             WorkloadStreamDefinition streamDefinition,
             AtomicBoolean hasFinished,
             AtomicBoolean forcedTerminate,
-            CompletionTimeWriter completionTimeWriter,
-            CompletionTimeReader completionTimeReader
-            )
+            CompletionTimeWriter completionTimeWriter )
     {
         super( OperationStreamExecutorServiceThread.class.getSimpleName() + "-" + System.currentTimeMillis() );
         this.operationExecutor = operationExecutor;
@@ -35,8 +32,7 @@ class OperationStreamExecutorServiceThread extends Thread
         this.forcedTerminate = forcedTerminate;
         this.initiatedTimeSubmittingOperationRetriever = new InitiatedTimeSubmittingOperationRetriever(
                 streamDefinition,
-                completionTimeWriter,
-                completionTimeReader
+                completionTimeWriter
         );
     }
 

--- a/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/org/ldbcouncil/snb/driver/workloads/interactive/LdbcSnbInteractiveWorkload.java
@@ -388,7 +388,6 @@ public class LdbcSnbInteractiveWorkload extends Workload
         Set<Class<? extends Operation>> dependencyAsynchronousOperationTypes = Sets.newHashSet();
 
         dependencyAsynchronousOperationTypes.addAll(enabledUpdateOperationTypes);
-        // dependentAsynchronousOperationTypes.addAll(enabledLongReadOperationTypes);
 
         ParquetLoader loader;
         try {
@@ -539,7 +538,7 @@ public class LdbcSnbInteractiveWorkload extends Workload
             gf.incrementing( workloadStartTimeAsMilli + readOperationInterleaveAsMilli,
                     readOperationInterleaveAsMilli );
 
-            Iterator<Operation> operationStream = gf.assignStartTimes(
+            Iterator<Operation> operationStream = gf.assignStartTimesWithSkipping(
                 operationStartTimes,
                 new QueryEventStreamReader(gf.repeating( eventOperationStream ))
             );

--- a/src/test/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorPerformanceTest.java
+++ b/src/test/java/org/ldbcouncil/snb/driver/runtime/executor/OperationStreamExecutorPerformanceTest.java
@@ -142,7 +142,6 @@ public class OperationStreamExecutorPerformanceTest
                         streamDefinition,
                         executor,
                         completionTimeWriter,
-                        completionTimeReader,
                         executorHasFinished,
                         forceThreadToTerminate
                 );
@@ -225,7 +224,6 @@ public class OperationStreamExecutorPerformanceTest
             WorkloadStreams.WorkloadStreamDefinition streamDefinition,
             OperationExecutor operationExecutor,
             CompletionTimeWriter completionTimeWriter,
-            CompletionTimeReader completionTimeReader,
             AtomicBoolean executorHasFinished,
             AtomicBoolean forceThreadToTerminate
     ) throws CompletionTimeException, MetricsCollectionException, DbException
@@ -237,8 +235,7 @@ public class OperationStreamExecutorPerformanceTest
                         streamDefinition,
                         executorHasFinished,
                         forceThreadToTerminate,
-                        completionTimeWriter,
-                        completionTimeReader
+                        completionTimeWriter
                 );
 
         return operationStreamExecutorThread;


### PR DESCRIPTION
Moves the temporal parameter checking to the merging iterators to prevent skipping of query types during execution.
This PR allows to skip the parameter during creation of the operations instead of skipping the query type, respecting the query frequencies.